### PR TITLE
RaymondRender now implements gin's render.Render interface.

### DIFF
--- a/options.go
+++ b/options.go
@@ -3,13 +3,13 @@ package ginraymond
 // RenderOptions is used to configure the renderer.
 type RenderOptions struct {
 	TemplateDir string
-	ContentType string
+	ContentType []string
 }
 
 // DefaultOptions constructs a RenderOptions struct with default settings.
 func DefaultOptions() *RenderOptions {
 	return &RenderOptions{
 		TemplateDir: "templates",
-		ContentType: "text/html; charset=utf-8",
+		ContentType: []string{"text/html; charset=utf-8"},
 	}
 }

--- a/render.go
+++ b/render.go
@@ -22,6 +22,9 @@ type RaymondRender struct {
 	Context  interface{}
 }
 
+// htmlContentType defines the content outputted by this renderer.
+var htmlContentType = []string{"text/html; charset=utf-8"}
+
 // New creates a new RaymondRender instance with custom Options.
 func New(options *RenderOptions) *RaymondRender {
 	return &RaymondRender{
@@ -68,4 +71,13 @@ func (r RaymondRender) Render(w http.ResponseWriter) error {
 	output, err := r.Template.Exec(r.Context)
 	w.Write([]byte(output))
 	return err
+}
+
+// WriteContentType writes header information about content ginraymond outputts.
+// This will now implement gin's render.Render interface.
+func (r RaymondRender) WriteContentType(w http.ResponseWriter) {
+	header := w.Header()
+	if val := header["Content-Type"]; len(val) == 0 {
+		header["Content-Type"] = htmlContentType
+	}
 }

--- a/render.go
+++ b/render.go
@@ -22,9 +22,6 @@ type RaymondRender struct {
 	Context  interface{}
 }
 
-// htmlContentType defines the content outputted by this renderer.
-var htmlContentType = []string{"text/html; charset=utf-8"}
-
 // New creates a new RaymondRender instance with custom Options.
 func New(options *RenderOptions) *RaymondRender {
 	return &RaymondRender{
@@ -60,14 +57,9 @@ func (r RaymondRender) Instance(name string, data interface{}) render.Render {
 	}
 }
 
-// Render should render the template to the response.
+// Render should write the content type, then render the template to the response.
 func (r RaymondRender) Render(w http.ResponseWriter) error {
-	// Unless already set, write the Content-Type header.
-	header := w.Header()
-	if val := header["Content-Type"]; len(val) == 0 {
-		header["Content-Type"] = []string{r.Options.ContentType}
-	}
-
+	r.WriteContentType(w)
 	output, err := r.Template.Exec(r.Context)
 	w.Write([]byte(output))
 	return err
@@ -78,6 +70,6 @@ func (r RaymondRender) Render(w http.ResponseWriter) error {
 func (r RaymondRender) WriteContentType(w http.ResponseWriter) {
 	header := w.Header()
 	if val := header["Content-Type"]; len(val) == 0 {
-		header["Content-Type"] = htmlContentType
+		header["Content-Type"] = r.Options.ContentType
 	}
 }

--- a/render.go
+++ b/render.go
@@ -73,7 +73,7 @@ func (r RaymondRender) Render(w http.ResponseWriter) error {
 	return err
 }
 
-// WriteContentType writes header information about content RaymondRender outputts.
+// WriteContentType writes header information about content RaymondRender outputs.
 // This will now implement gin's render.Render interface.
 func (r RaymondRender) WriteContentType(w http.ResponseWriter) {
 	header := w.Header()

--- a/render.go
+++ b/render.go
@@ -73,7 +73,7 @@ func (r RaymondRender) Render(w http.ResponseWriter) error {
 	return err
 }
 
-// WriteContentType writes header information about content ginraymond outputts.
+// WriteContentType writes header information about content RaymondRender outputts.
 // This will now implement gin's render.Render interface.
 func (r RaymondRender) WriteContentType(w http.ResponseWriter) {
 	header := w.Header()


### PR DESCRIPTION
**Issue**: Gin's render.Render interface specified a '_WriteContentType(w http.ResponseWriter)_' that wasn't implemented by RaymondRender. This is a maintenance issue.

**Resolution**: RaymondRender now holds a variable called _htmlContentType_ that remembers the type of content it outputs. This is used in RaymondRender's _implementation_ of 'WriteContentType', which writes header information to the ResponseWriter.